### PR TITLE
Add std/portable to list of exports

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,7 @@ under the licensing terms detailed in LICENSE:
 * Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
 * Gabor Greif <ggreif@gmail.com>
 * Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+* Chance Snow <git@chancesnow.me>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "types": "index.d.ts",
   "exports": {
     ".": "./index.js",
+    "./std/portable": "./std/portable/index.js",
     "./lib/loader": {
       "import": "./lib/loader/index.js",
       "require": "./lib/loader/umd/index.js"


### PR DESCRIPTION
According to the [Portability](https://www.assemblyscript.org/portability.html#portable-stdlib) documentation, I should be able to `require("assemblyscript/std/portable")` to make use of the porttable standard library. However, Node crashes with the following error:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './std/portable' is not defined by "exports" in /home/chances/GitHub/teraflop-d/source/scripting/api/node_modules/assemblyscript/package.json
    at applyExports (internal/modules/cjs/loader.js:487:9)
    at resolveExports (internal/modules/cjs/loader.js:503:23)
    at Function.Module._findPath (internal/modules/cjs/loader.js:631:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:949:27)
    at Function.Module._load (internal/modules/cjs/loader.js:838:27)
    at Module.require (internal/modules/cjs/loader.js:1022:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/home/chances/GitHub/teraflop-d/source/scripting/api/lib/index.js:4:1)
    at Module._compile (internal/modules/cjs/loader.js:1118:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1138:10) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

Adding `std/portable` to the list of exports resolves the issue.

---

- [x] I've read the contributing guidelines